### PR TITLE
feat: `mut` keyword in lalrpop-token

### DIFF
--- a/syntaxes/lalrpop.tmLanguage.json
+++ b/syntaxes/lalrpop.tmLanguage.json
@@ -488,9 +488,12 @@
         },
         "lalrpop-token": {
             "name": "support.other.rule.token",
-            "begin": "<\\s*(([A-Za-z_][A-Za-z_0-9]*)\\s*:)?",
+            "begin": "<\\s*((mut)?\\s*([A-Za-z_][A-Za-z_0-9]*)\\s*:)?",
             "beginCaptures": {
                 "2": {
+                    "name": "storage.modifier.mut.rust"
+                },
+                "3": {
                     "name": "variable.other.token"
                 }
             },


### PR DESCRIPTION
Lalrpop 允许[在捕获中使用 `mut` 关键字](http://lalrpop.github.io/lalrpop/tutorial/006_macros.html#:~:text=The%20mut%20makes%20v%20mutable%20in%20the%20action%20code.)。

![image](https://user-images.githubusercontent.com/21151119/157168273-6dd86e70-deeb-49cf-8e58-6343f3bf937d.png)
